### PR TITLE
Fixed BluetoothInterface for newer btlewrap versions

### DIFF
--- a/parrotflowerpower/parrotflowerpower_poller.py
+++ b/parrotflowerpower/parrotflowerpower_poller.py
@@ -33,7 +33,7 @@ class ParrotFlowerPowerPoller(object):
         """
 
         self._mac = mac
-        self._bt_interface = BluetoothInterface(backend, adapter)
+        self._bt_interface = BluetoothInterface(backend, adapter=adapter)
         self._cache = None
         self._cache_timeout = timedelta(seconds=cache_timeout)
         self._last_read = None


### PR DESCRIPTION
Hi,

I'm not sure if this could break older btlewrap installations!
But I'm running Home Assistant on a QNAP NAS and I am unable to change the btlewrap version.
So, with this patch it runs fine now.

Thx for this addons.

Take a look at https://github.com/basnijholt/miflora/issues/135 and https://github.com/basnijholt/miflora/pull/133

